### PR TITLE
Allow switching from one Dialog to another

### DIFF
--- a/src/DialogManager.php
+++ b/src/DialogManager.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace KootLabs\TelegramBotDialogs;
 
+use KootLabs\TelegramBotDialogs\Exceptions\ControlFlow\SwitchToAnotherDialog;
 use KootLabs\TelegramBotDialogs\Objects\BotInitiatedUpdate;
 use KootLabs\TelegramBotDialogs\Storages\Store;
 use Psr\SimpleCache\CacheInterface;
@@ -72,7 +73,14 @@ final class DialogManager
             return;
         }
 
-        $dialog->proceed($update);
+        try {
+            $dialog->proceed($update);
+        } catch (SwitchToAnotherDialog $exception) {
+            $this->forgetDialogState($dialog);
+            $this->activate($exception->nextDialog);
+            $this->proceed($update);
+            return;
+        }
 
         if ($dialog->isEnd()) {
             $this->forgetDialogState($dialog);

--- a/src/Exceptions/ControlFlow/DialogControlFlowException.php
+++ b/src/Exceptions/ControlFlow/DialogControlFlowException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KootLabs\TelegramBotDialogs\Exceptions\ControlFlow;
+
+use KootLabs\TelegramBotDialogs\Exceptions\DialogException;
+
+/** @internal */
+interface DialogControlFlowException extends DialogException
+{
+}

--- a/src/Exceptions/ControlFlow/SwitchToAnotherDialog.php
+++ b/src/Exceptions/ControlFlow/SwitchToAnotherDialog.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KootLabs\TelegramBotDialogs\Exceptions\ControlFlow;
+
+use KootLabs\TelegramBotDialogs\Dialog;
+
+/**
+ * @experimental
+ * Used when needed to switch to another Dialog from the current one.
+ */
+final class SwitchToAnotherDialog extends \LogicException implements DialogControlFlowException
+{
+    public ?Dialog $nextDialog = null;
+
+    private function __construct(Dialog $nextDialog)
+    {
+        $this->nextDialog = $nextDialog;
+        parent::__construct();
+    }
+
+    public static function to(Dialog $nextDialog): self
+    {
+        return new self($nextDialog);
+    }
+}

--- a/src/Exceptions/ControlFlow/SwitchToAnotherDialog.php
+++ b/src/Exceptions/ControlFlow/SwitchToAnotherDialog.php
@@ -8,6 +8,7 @@ use KootLabs\TelegramBotDialogs\Dialog;
 
 /**
  * @experimental
+ * @api
  * Used when needed to switch to another Dialog from the current one.
  */
 final class SwitchToAnotherDialog extends \LogicException implements DialogControlFlowException


### PR DESCRIPTION
Allow switching from one Dialog to another

Needed in rare cases. Experimental. Can be removed in any minor release.