### PR TITLE
Fix for afterLastStep function call in Dialog/proceed.

### DIFF
--- a/src/Dialog.php
+++ b/src/Dialog.php
@@ -99,11 +99,6 @@ abstract class Dialog
             $this->beforeFirstStep($update);
         }
 
-        if ($this->isEnd()) {
-            $this->afterLastStep($update);
-            return;
-        }
-
         if (! array_key_exists($currentStepIndex, $this->steps)) {
             throw new InvalidDialogStep("Undefined step with index {$currentStepIndex}.");
         }
@@ -127,6 +122,10 @@ abstract class Dialog
             }
         } else {
             throw new InvalidDialogStep('Unknown format of the step.');
+        }
+
+        if ($this->isLastStep()) {
+            $this->afterLastStep($update);
         }
 
         // Step forward only if did not change inside the step handler
@@ -220,6 +219,12 @@ abstract class Dialog
     final public function isStart(): bool
     {
         return $this->next === 0;
+    }
+
+    /** Check if Dialog on the last step */
+    final public function isLastStep(): bool
+    {
+        return $this->next == count($this->steps) - 1;
     }
 
     /** Check if Dialog ended */

--- a/tests/TestDialogs/PassiveTestDialog.php
+++ b/tests/TestDialogs/PassiveTestDialog.php
@@ -29,6 +29,7 @@ final class PassiveTestDialog extends Dialog
 
     public function step3(Update $update): void
     {
+        $this->jump("step2");
         return;
     }
 


### PR DESCRIPTION
Closes #17

 Fix for afterLastStep function call in Dialog/proceed. afterProceedJumpToIndex took into account = afterLastStep should be called if flow jumps from the last step. PassiveTestDialog updated to test this. isLastStep added because isEnd can not be used in this case.