### PR TITLE
Added deactivate function to DialogManager

### DIFF
--- a/src/DialogManager.php
+++ b/src/DialogManager.php
@@ -41,12 +41,12 @@ final class DialogManager
     }
 
     /**
-     * @api Deactivate existing Dialog.
+     * @api Remove current active Dialog from a Storage.
      */
-    public function deactivate(Update $update): void
+    public function forgetActiveDialog(Update $update): void
     {
         $dialog = $this->getDialogInstance($update);
-        if(isset($dialog)){
+        if ($dialog instanceof Dialog) {
             $this->forgetDialogState($dialog);
         }
     }

--- a/src/DialogManager.php
+++ b/src/DialogManager.php
@@ -41,6 +41,17 @@ final class DialogManager
     }
 
     /**
+     * @api Deactivate existing Dialog.
+     */
+    public function deactivate(Update $update): void
+    {
+        $dialog = $this->getDialogInstance($update);
+        if(isset($dialog)){
+            $this->forgetDialogState($dialog);
+        }
+    }
+
+    /**
      * Initiate a new Dialog from server side (e.g. by cron).
      * Note, a User firstly should start a chat with a bot (bot can't initiate a chat — this is TG Bot API limitation).
      * @api


### PR DESCRIPTION
Added public function "deactivate" to deactivate any existing dialog from outside. This will be useful in case when user inputs command with priority higher, than dialogs, and any dialog should be interrupted. The most popular case is  /start command.