### PR TITLE
Switch (to another step) added, end() modified in Dialog. Tests added.

### DIFF
--- a/docs/advanced-dialogs.md
+++ b/docs/advanced-dialogs.md
@@ -23,5 +23,5 @@ final class HelloDialog extends Dialog
 ```
 In this case, if you don't need any logic inside the step handler - you can don't define it. Just put the response inside the step definition. It works good for welcome messages, messages with tips/advices and so on. If you want format response with markdown, just set `markdown` field to `true`.
 
-Also, you can control the dialog direction in step by defining `jump ` and `end` fields. `jump` acts as `jump()` method - dialog jumps to particular step. `end` field, is set to `true`, ends dialog after current step.
+Also, you can control the dialog direction in step by defining `jump`, `switch` and `end` fields. `jump` acts as `jump()` method - dialog jumps to particular step. `switch` acts as `switch()` method - dialog switch to particular step. `end` field, is set to `true`, ends dialog after current step.
 

--- a/src/Dialog.php
+++ b/src/Dialog.php
@@ -7,6 +7,7 @@ namespace KootLabs\TelegramBotDialogs;
 use Illuminate\Support\Collection;
 use KootLabs\TelegramBotDialogs\Exceptions\InvalidDialogStep;
 use KootLabs\TelegramBotDialogs\Exceptions\UnexpectedUpdateType;
+use KootLabs\TelegramBotDialogs\Exceptions\ControlFlow\SwitchToAnotherStep;
 use Telegram\Bot\Api;
 use Telegram\Bot\Objects\Update;
 
@@ -180,13 +181,30 @@ abstract class Dialog
         // override the method to add your logic here
     }
 
-    /** Jump to the particular step of the Dialog. */
+    /**
+     * Jump to the particular step of the Dialog.
+     * This step will be executed in the next proceed iteration.
+     */
     final protected function jump(string $stepName): void
     {
         foreach ($this->steps as $index => $value) {
             if ($value === $stepName || (is_array($value) && $value['name'] === $stepName)) {
                 $this->afterProceedJumpToIndex = $index;
                 break;
+            }
+        }
+    }
+
+    /**
+     * Switch to the particular step of the Dialog.
+     * This step will be executed at once with new proceed iteration.
+     */
+    final protected function switch(string $stepName): void
+    {
+        foreach ($this->steps as $index => $value) {
+            if ($value === $stepName || (is_array($value) && $value['name'] === $stepName)) {
+                $this->next = $index;
+                throw new SwitchToAnotherStep();
             }
         }
     }
@@ -274,6 +292,10 @@ abstract class Dialog
             }
 
             $this->bot->sendMessage($params);
+        }
+
+        if (! empty($stepConfig['switch'])) {
+            $this->switch($stepConfig['switch']);
         }
 
         if (! empty($stepConfig['jump'])) {

--- a/src/Dialog.php
+++ b/src/Dialog.php
@@ -209,10 +209,16 @@ abstract class Dialog
         }
     }
 
-    /** Move Dialog’s cursor to the end. */
+    /**
+     * Move Dialog’s cursor to the end.
+     * If called in step, this step and all flow after it will be completed, then dialog will be forgotten.
+     * Works the same if called in last step.
+     */
     final public function end(): void
     {
-        $this->next = count($this->steps);
+        if(!$this->isLastStep()) {
+            $this->next = count($this->steps);
+        }
     }
 
     /**

--- a/src/DialogManager.php
+++ b/src/DialogManager.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace KootLabs\TelegramBotDialogs;
 
 use KootLabs\TelegramBotDialogs\Exceptions\ControlFlow\SwitchToAnotherDialog;
+use KootLabs\TelegramBotDialogs\Exceptions\ControlFlow\SwitchToAnotherStep;
 use KootLabs\TelegramBotDialogs\Objects\BotInitiatedUpdate;
 use Telegram\Bot\Api;
 use Telegram\Bot\Objects\Update;
@@ -84,6 +85,8 @@ final class DialogManager
         }
 
         try {
+            $dialog->proceed($update);
+        } catch (SwitchToAnotherStep $exception) {
             $dialog->proceed($update);
         } catch (SwitchToAnotherDialog $exception) {
             $this->forgetDialogState($dialog);

--- a/src/Exceptions/ControlFlow/SwitchToAnotherStep.php
+++ b/src/Exceptions/ControlFlow/SwitchToAnotherStep.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace KootLabs\TelegramBotDialogs\Exceptions\ControlFlow;
+
+/**
+ * @experimental
+ * @api
+ * Used when needed to switch to another step of current dialog.
+ */
+final class SwitchToAnotherStep extends \LogicException implements DialogControlFlowException {}

--- a/tests/DialogManagerTest.php
+++ b/tests/DialogManagerTest.php
@@ -85,17 +85,13 @@ final class DialogManagerTest extends TestCase
     }
 
     #[Test]
-    public function it_throws_custom_exception_when_afterLastStep_called_in_dialog_end(): void
+    public function it_throws_custom_exception_when_switch_to_another_step(): void
     {
         $dialogManager = $this->instantiateDialogManager();
         $dialog = new PassiveTestDialog(self::RANDOM_CHAT_ID);
 
         $dialogManager->activate($dialog);
-        $dialog->proceed(new Update(['message' => ['chat' => ['id' => self::RANDOM_CHAT_ID]]]));
-        $dialog->proceed(new Update(['message' => ['chat' => ['id' => self::RANDOM_CHAT_ID]]]));
-
         $this->expectException(\LogicException::class);
-
         $dialog->proceed(new Update(['message' => ['chat' => ['id' => self::RANDOM_CHAT_ID]]]));
     }
 }

--- a/tests/DialogTest.php
+++ b/tests/DialogTest.php
@@ -152,4 +152,33 @@ final class DialogTest extends TestCase
         $this->expectException(\LogicException::class);
         $dialog->proceed($this->buildUpdateOfRandomType());
     }
+
+    #[Test]
+    public function it_throws_custom_exception_when_afterLastStep_called_when_end_is_called_in_the_last_step(): void
+    {
+        $dialog = new class (self::RANDOM_CHAT_ID) extends Dialog {
+            protected array $steps = ['step1', 'step2'];
+
+            public function step1(): void
+            {
+                return;
+            }
+
+            public function step2(): void
+            {
+                $this->end();
+                return;
+            }
+
+            protected function afterLastStep(Update $update): void
+            {
+                throw new \LogicException(__METHOD__." is called for testing purposes.");
+            }
+        };
+
+        $dialog->proceed($this->buildUpdateOfRandomType());
+
+        $this->expectException(\LogicException::class);
+        $dialog->proceed($this->buildUpdateOfRandomType());
+    }
 }

--- a/tests/DialogTest.php
+++ b/tests/DialogTest.php
@@ -6,6 +6,7 @@ namespace KootLabs\TelegramBotDialogs\Tests;
 
 use KootLabs\TelegramBotDialogs\Dialog;
 use KootLabs\TelegramBotDialogs\Exceptions\InvalidDialogStep;
+use Telegram\Bot\Objects\Update;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 
@@ -115,5 +116,40 @@ final class DialogTest extends TestCase
         $dialog->proceed($this->buildUpdateOfRandomType());
 
         $this->assertSame(3, $dialog->count);
+    }
+
+    #[Test]
+    public function it_throws_custom_exception_when_afterLastStep_called_in_dialog_end(): void
+    {
+        $dialog = new class (self::RANDOM_CHAT_ID) extends Dialog {
+            protected array $steps = ['step1', 'step2', 'step3'];
+
+            public function step1(): void
+            {
+                return;
+            }
+
+            public function step2(): void
+            {
+                return;
+            }
+
+            public function step3(): void
+            {
+                $this->jump("step2");
+                return;
+            }
+
+            protected function afterLastStep(Update $update): void
+            {
+                throw new \LogicException(__METHOD__." is called for testing purposes.");
+            }
+        };
+
+        $dialog->proceed($this->buildUpdateOfRandomType());
+        $dialog->proceed($this->buildUpdateOfRandomType());
+
+        $this->expectException(\LogicException::class);
+        $dialog->proceed($this->buildUpdateOfRandomType());
     }
 }

--- a/tests/TestDialogs/PassiveTestDialog.php
+++ b/tests/TestDialogs/PassiveTestDialog.php
@@ -15,26 +15,25 @@ use Telegram\Bot\Objects\Update;
 final class PassiveTestDialog extends Dialog
 {
     /** @var list<string> List of method to execute. The order defines the sequence */
-    protected array $steps = ['step1', 'step2', 'step3'];
-
-    public function step1(Update $update): void
-    {
-        return;
-    }
+    protected array $steps = [
+        [
+            'name' => 'step1',
+            'switch' => 'step2',
+        ],
+        'step2', 'step3', 'step4'];
 
     public function step2(Update $update): void
     {
+        $this->switch("step4");
         return;
     }
 
     public function step3(Update $update): void
     {
-        $this->jump("step2");
         return;
     }
 
-    /** @inheritDoc */
-    protected function afterLastStep(Update $update): void
+    public function step4(Update $update): void
     {
         throw new \LogicException(__METHOD__." is called for testing purposes.");
     }


### PR DESCRIPTION
Switch for Dialog
- Added in Dialog `switch` method to switch to new step and proceed at once
- Added `SwitchToAnotherStepException`, which is thrown by `switch` method
- Added catch of exception in DialogManager
- Added switch to proceedConfiguredStep in Dialog and in advanced-dialogs.md
- Added tests for all that:
-- modified PassiveTestDialog to test switch and switch-in-ConfiguredSteps in DialogManagerTest.php
-- moved test of afterLastStep-after-jump from DialogMangerTest.php to DialogTest.php

End function for Dialog
- Modified end() function in Dialog to have the same result if called in last step and in some other step:
--step complpeted
-- all after step completed (afterEveryStep for any step, + afterLastStep for last step)
-- dialog forgotten
- Added test in DialogTest.php for that