### PR TITLE
Enhance `DialogManager::findDialogKeyForStore` to make it more type-specific

### DIFF
--- a/src/DialogManager.php
+++ b/src/DialogManager.php
@@ -103,11 +103,10 @@ final class DialogManager
     /** @return non-empty-string|null */
     private function findDialogKeyForStore(Update $update): ?string
     {
-        if (! $update->getChat()->has('id'))
-        {
+        $chatId = $update->getChat()->get('id');
+        if (! is_int($chatId)) {
+            // Update doesn't have a Chat ID, so it's not possible to find a Dialog.
             return null;
-        } else {
-            $chatId = $update->getChat()->get('id');
         }
 
         // As for 1-1 personal chat and multi-user chat, where bot should treat all users messages as one dialog
@@ -116,14 +115,14 @@ final class DialogManager
             return $chatBoundedDialogKey;
         }
 
-        if (! $update->getMessage()->has('from'))
-        {
+        $message = $update->getMessage();
+        if (! $message instanceof \Telegram\Bot\Objects\Message) {
             return null;
-        } else {
-            $userId = $update->getMessage()->get('from')->get('id');
         }
 
-        // As for multi-user chat, where bot should treat all messages of every user as separate dialog
+        $userId = $message->from?->id;
+
+        // As for multi-user chat, where bot should treat all messages of every user as a separate dialog
         $userBoundedDialogKey = $this->generateDialogKey($chatId, $userId);
         if ($this->repository->has($userBoundedDialogKey)) {
             return $userBoundedDialogKey;


### PR DESCRIPTION
`$update->getMessage()` always returns Collection instance or child of this class, that makes code less predictable due to a lot of magic inside the Collection class. This PR focuses on improving `findDialogKeyForStore` to make it more readable for developers and static analyzers.


Please merge it after merging "Add more tests for all types of Updates (incl. json fixtures) #32" (as we firstly need to have a great test coverage for all possible Update types)