### PR TITLE
Cleaner method names

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,80 @@
+# Upgrade Guide
+
+## Upgrading from 0.13 to 1.0
+
+This is a major release that includes several backward-incompatible changes. Please review this guide thoroughly before upgrading.
+
+### Method Renames
+
+#### Dialog Class
+
+The following methods have been renamed to improve clarity and consistency:
+
+```php
+// Before                   // After
+$dialog->isStart()          $dialog->isAtStart()
+$dialog->isEnd()            $dialog->isComplete()
+$dialog->end()              $dialog->complete()
+$dialog->switch()           $dialog->switchToStep()
+$dialog->proceed()          $dialog->executeStep()  // internal method
+$dialog->beforeEveryStep()  $dialog->beforeStep()
+$dialog->afterEveryStep()   $dialog->afterStep()
+```
+
+#### DialogManager Class
+
+```php
+// Before                  // After
+$manager->proceed()        $manager->processUpdate()
+$manager->exists()         $manager->hasActiveDialog()
+```
+
+### Removed Methods
+
+The following deprecated methods have been removed:
+
+```php
+// Dialog Class
+$dialog->start()           // Use DialogManager::processUpdate() instead
+$dialog->jump()            // Use nextStep() instead
+$dialog->remember()        // Use $dialog->memory directly
+$dialog->forget()          // Use $dialog->memory directly
+$dialog->beforeAllStep()   // Use beforeFirstStep() instead
+$dialog->afterAllStep()    // Use afterLastStep() instead
+
+// Example migration for memory management
+// Before
+$this->remember('key', 'value');
+$value = $this->memory->get('key');
+$this->forget('key');
+
+// After
+$this->memory->put('key', 'value');
+$value = $this->memory->get('key');
+$this->memory->forget('key');
+```
+
+### Internal Methods Renames
+
+The following internal methods in DialogManager have been renamed:
+
+```php
+// Before                     // After
+findDialogKeyForStore()       resolveDialogKey()
+getDialogInstance()           resolveActiveDialog()
+storeDialogState()            persistDialog()
+readDialogState()             retrieveDialog()
+forgetDialogState()           removeDialog()
+```
+
+Note: These are internal changes and shouldn't affect your application unless you've extended DialogManager.
+
+### Bot-Initiated Dialogs
+
+```php
+// Before
+$manager->startNewDialogInitiatedByBot($dialog);
+
+// After
+$manager->initiateDialog($dialog);
+```

--- a/docs/laravel-simple-example.md
+++ b/docs/laravel-simple-example.md
@@ -5,7 +5,7 @@ It’s possible to use the package in 2 ways:
 2. By reacting to specific Messages/Updates
 
 ## Reacting to specific Messages/Updates
-> [!IMPORTANT]  
+> [!IMPORTANT]
 > Note, this example uses Artisan command for testing purposes only.
 > It’s not recommended to use this approach in production.
 > Instead, please use a Controller that listens to income webhooks.
@@ -25,12 +25,12 @@ Artisan::command('telegram:test', function (DialogManager $dialogs, BotsManager 
 
     /** @var \Telegram\Bot\Objects\Update $update */
     foreach ($updates as $update) {
-        if ($dialogs->exists($update)) {
-            $dialogs->proceed($update);
+        if ($dialogs->hasActiveDialog($update)) {
+            $dialogs->processUpdate($update);
         } elseif (str_contains($update->getMessage()?->text, 'hello bot')) {
             $dialog = new HelloExampleDialog($update->getChat()->id);
             $dialogs->activate($dialog);
-            $dialogs->proceed($update);
+            $dialogs->processUpdate($update);
         } else {
             $botsManager->sendMessage([ // fallback message
                 'chat_id' => $update->getChat()->id,

--- a/docs/using-without-framework.md
+++ b/docs/using-without-framework.md
@@ -2,11 +2,12 @@
 
 1. Install the package via composer
 2. Install `symfony/cache` via composer
-3. Install a PSR-16 storage (to store dialog states between requests), for example `composer require symfony/cache`: 
+3. Install a PSR-16 storage (to store dialog states between requests), for example `composer require symfony/cache`:
    - a. If you have Redis installed, you can use File driver (see example below)
    - b. You have Redis installed: See `RedisAdapter` example below
 
 File storage example.
+
 ```php
 use KootLabs\TelegramBotDialogs\DialogManager;
 use KootLabs\TelegramBotDialogs\DialogRepository;
@@ -16,7 +17,7 @@ use Symfony\Component\Cache\Psr16Cache;
 
 require __DIR__.'/vendor/autoload.php';
 
-/** @todo replace by your token, {@see https://core.telegram.org/bots#6-botfather} */ 
+/** @todo replace by your token, {@see https://core.telegram.org/bots#6-botfather} */
 $token = '110201543:AAHdqTcvCH1vGWJxfSeofSAs0K5PALDsaw';
 $bot = new \Telegram\Bot\Api($token);
 
@@ -28,11 +29,11 @@ $updates = $bot->getUpdates(['offset' => $store->get('latest_update_id') + 1]);
 
 foreach ($updates as $update) {
     echo 'Received update: '.$update->update_id.PHP_EOL;
-    if (! $dialogManager->exists($update)) {
+    if (! $dialogManager->hasActiveDialog($update)) {
         $dialog = new HelloExampleDialog($update->getChat()->id, $bot);
         $dialogManager->activate($dialog);
     }
-    $dialogManager->proceed($update);
+    $dialogManager->processUpdate($update);
 }
 
 if (isset($update)) {
@@ -42,7 +43,7 @@ if (isset($update)) {
 }
 ```
 
-> [!IMPORTANT]  
+> [!IMPORTANT]
 > a note for this example: The overhead of filesystem IO (FilesystemAdapter) often makes this adapter one of the slower choices.
 > If throughput is paramount, the in-memory adapters (
 > [Apcu](https://symfony.com/doc/current/components/cache/adapters/apcu_adapter.html#apcu-adapter),

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -7,6 +7,9 @@
     <PossiblyUnusedMethod>
       <code><![CDATA[afterAllStep]]></code>
       <code><![CDATA[beforeAllStep]]></code>
+      <code><![CDATA[end]]></code>
+      <code><![CDATA[isEnd]]></code>
+      <code><![CDATA[isStart]]></code>
       <code><![CDATA[proceed]]></code>
     </PossiblyUnusedMethod>
   </file>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -7,6 +7,7 @@
     <PossiblyUnusedMethod>
       <code><![CDATA[afterAllStep]]></code>
       <code><![CDATA[beforeAllStep]]></code>
+      <code><![CDATA[proceed]]></code>
     </PossiblyUnusedMethod>
   </file>
   <file src="src/Laravel/DialogsServiceProvider.php">

--- a/src/Dialog.php
+++ b/src/Dialog.php
@@ -97,7 +97,13 @@ abstract class Dialog
     final public function start(Update $update): void
     {
         $this->next = 0;
-        $this->proceed($update);
+        $this->executeStep($update);
+    }
+
+    /** @deprecated Will be removed in v1.0. */
+    final public function proceed(Update $update): void
+    {
+        $this->executeStep($update);
     }
 
     /**
@@ -106,7 +112,7 @@ abstract class Dialog
      * @throws \KootLabs\TelegramBotDialogs\Exceptions\InvalidDialogStep
      * @throws \Telegram\Bot\Exceptions\TelegramSDKException
      */
-    final public function proceed(Update $update): void
+    final public function executeStep(Update $update): void
     {
         $currentStepIndex = $this->next;
 

--- a/src/DialogManager.php
+++ b/src/DialogManager.php
@@ -69,11 +69,11 @@ final class DialogManager
     }
 
     /**
-     * @api
-     * Run next step of the active Dialog.
-     * This is a thin wrapper for {@see \KootLabs\TelegramBotDialogs\Dialog::proceed}
+     * Run the next step of the active Dialog.
+     * This is a thin wrapper for {@see \KootLabs\TelegramBotDialogs\Dialog::executeStep}
      * to store and restore Dialog state between request-response calls.
      * @throws \Telegram\Bot\Exceptions\TelegramSDKException
+     * @api
      */
     public function proceed(Update $update): void
     {
@@ -83,9 +83,9 @@ final class DialogManager
         }
 
         try {
-            $dialog->proceed($update);
+            $dialog->executeStep($update);
         } catch (SwitchToAnotherStep $exception) {
-            $dialog->proceed($update);
+            $dialog->executeStep($update);
         } catch (SwitchToAnotherDialog $exception) {
             $this->forgetDialogState($dialog);
             $this->activate($exception->nextDialog);

--- a/tests/DialogConfigurableStepsTest.php
+++ b/tests/DialogConfigurableStepsTest.php
@@ -58,9 +58,9 @@ final class DialogConfigurableStepsTest extends TestCase
                 ],
             ];
 
-            protected function afterEveryStep(Update $update, int $step): void
+            protected function afterEveryStep(Update $update, int $stepIndex): void
             {
-                $this->stepsExecuted[] = $step;
+                $this->stepsExecuted[] = $stepIndex;
             }
         };
 
@@ -98,9 +98,9 @@ final class DialogConfigurableStepsTest extends TestCase
                 ],
             ];
 
-            protected function afterEveryStep(Update $update, int $step): void
+            protected function afterEveryStep(Update $update, int $stepIndex): void
             {
-                $this->stepsExecuted[] = $step;
+                $this->stepsExecuted[] = $stepIndex;
             }
         };
 
@@ -129,7 +129,7 @@ final class DialogConfigurableStepsTest extends TestCase
 
         $dialog->executeStep($this->buildUpdateOfRandomType());
 
-        $this->assertTrue($dialog->isEnd());
+        $this->assertTrue($dialog->isComplete());
     }
 
     #[Test]
@@ -147,12 +147,12 @@ final class DialogConfigurableStepsTest extends TestCase
                 ],
             ];
 
-            protected function beforeEveryStep(Update $update, int $step): void
+            protected function beforeEveryStep(Update $update, int $stepIndex): void
             {
                 $this->beforeStepCalled = true;
             }
 
-            protected function afterEveryStep(Update $update, int $step): void
+            protected function afterEveryStep(Update $update, int $stepIndex): void
             {
                 $this->afterStepCalled = true;
             }

--- a/tests/DialogConfigurableStepsTest.php
+++ b/tests/DialogConfigurableStepsTest.php
@@ -34,7 +34,7 @@ final class DialogConfigurableStepsTest extends TestCase
 
         $this->expectException(InvalidDialogStep::class);
 
-        $dialog->proceed($this->buildUpdateOfRandomType());
+        $dialog->executeStep($this->buildUpdateOfRandomType());
     }
 
     #[Test]
@@ -65,9 +65,9 @@ final class DialogConfigurableStepsTest extends TestCase
         };
 
         try {
-            $dialog->proceed($this->buildUpdateOfRandomType());
+            $dialog->executeStep($this->buildUpdateOfRandomType());
         } catch (SwitchToAnotherStep) {
-            $dialog->proceed($this->buildUpdateOfRandomType());
+            $dialog->executeStep($this->buildUpdateOfRandomType());
         }
 
         // Only step 2 (third) should be in stepsExecuted because the first step
@@ -104,8 +104,8 @@ final class DialogConfigurableStepsTest extends TestCase
             }
         };
 
-        $dialog->proceed($this->buildUpdateOfRandomType());
-        $dialog->proceed($this->buildUpdateOfRandomType());
+        $dialog->executeStep($this->buildUpdateOfRandomType());
+        $dialog->executeStep($this->buildUpdateOfRandomType());
 
         $this->assertSame([0, 2], $dialog->stepsExecuted);
     }
@@ -127,7 +127,7 @@ final class DialogConfigurableStepsTest extends TestCase
             ];
         };
 
-        $dialog->proceed($this->buildUpdateOfRandomType());
+        $dialog->executeStep($this->buildUpdateOfRandomType());
 
         $this->assertTrue($dialog->isEnd());
     }
@@ -158,7 +158,7 @@ final class DialogConfigurableStepsTest extends TestCase
             }
         };
 
-        $dialog->proceed($this->buildUpdateOfRandomType());
+        $dialog->executeStep($this->buildUpdateOfRandomType());
 
         $this->assertTrue($dialog->beforeStepCalled);
         $this->assertTrue($dialog->afterStepCalled);

--- a/tests/DialogManagerTest.php
+++ b/tests/DialogManagerTest.php
@@ -40,7 +40,7 @@ final class DialogManagerTest extends TestCase
         $dialog = new HelloExampleDialog(self::RANDOM_CHAT_ID);
 
         $dialogManager->activate($dialog);
-        $exist = $dialogManager->exists(new Update(['message' => ['chat' => ['id' => self::RANDOM_CHAT_ID]]]));
+        $exist = $dialogManager->hasActiveDialog(new Update(['message' => ['chat' => ['id' => self::RANDOM_CHAT_ID]]]));
 
         $this->assertTrue($exist);
     }
@@ -52,7 +52,7 @@ final class DialogManagerTest extends TestCase
         $dialog = new HelloExampleDialog(self::RANDOM_CHAT_ID, null, self::RANDOM_USER_ID);
 
         $dialogManager->activate($dialog);
-        $existResult = $dialogManager->exists(new Update(['message' => [
+        $existResult = $dialogManager->hasActiveDialog(new Update(['message' => [
             'chat' => ['id' => self::RANDOM_CHAT_ID],
             'from' => ['id' => self::RANDOM_USER_ID],
         ]]));
@@ -65,7 +65,7 @@ final class DialogManagerTest extends TestCase
     {
         $dialogManager = $this->instantiateDialogManager();
 
-        $existResult = $dialogManager->exists(new Update(['message' => [
+        $existResult = $dialogManager->hasActiveDialog(new Update(['message' => [
             'chat' => ['id' => self::RANDOM_CHAT_ID],
             'from' => ['id' => self::RANDOM_USER_ID],
         ]]));
@@ -80,7 +80,7 @@ final class DialogManagerTest extends TestCase
         $dialog = new HelloExampleDialog(self::RANDOM_CHAT_ID);
         $dialogManager->activate($dialog);
 
-        $existResult = $dialogManager->exists(new Update(['message' => [
+        $existResult = $dialogManager->hasActiveDialog(new Update(['message' => [
             'chat' => ['id' => 43],
             'from' => ['id' => self::RANDOM_USER_ID]],
         ]));
@@ -109,7 +109,7 @@ final class DialogManagerTest extends TestCase
         $dialog = new PassiveTestDialog($initialUpdate->getChat()->id);
         $dialogManager->activate($dialog);
 
-        $dialogIsFound = $dialogManager->exists($followingUpUpdate);
+        $dialogIsFound = $dialogManager->hasActiveDialog($followingUpUpdate);
 
         $this->assertTrue($dialogIsFound);
     }

--- a/tests/DialogManagerTest.php
+++ b/tests/DialogManagerTest.php
@@ -96,7 +96,7 @@ final class DialogManagerTest extends TestCase
 
         $dialogManager->activate($dialog);
         $this->expectException(\LogicException::class);
-        $dialog->proceed(new Update(['message' => ['chat' => ['id' => self::RANDOM_CHAT_ID]]]));
+        $dialog->executeStep(new Update(['message' => ['chat' => ['id' => self::RANDOM_CHAT_ID]]]));
     }
 
     #[Test]

--- a/tests/DialogSerializationTest.php
+++ b/tests/DialogSerializationTest.php
@@ -37,7 +37,7 @@ final class DialogSerializationTest extends TestCase
     {
         $bot = $this->createBotWithQueuedResponse();
         $dialog = new HelloExampleDialog(self::RANDOM_CHAT_ID, $bot);
-        $dialog->proceed(new Update([]));
+        $dialog->executeStep(new Update([]));
 
         $unserializedDialog = unserialize(serialize($dialog));
 

--- a/tests/DialogSerializationTest.php
+++ b/tests/DialogSerializationTest.php
@@ -29,7 +29,7 @@ final class DialogSerializationTest extends TestCase
         $this->assertSame($dialog->getChatId(), $unserializedDialog->getChatId());
         $this->assertSame($dialog->getUserId(), $unserializedDialog->getUserId());
         $this->assertSame($dialog->ttl(), $unserializedDialog->ttl());
-        $this->assertSame($dialog->isStart(), $unserializedDialog->isStart());
+        $this->assertSame($dialog->isAtStart(), $unserializedDialog->isStart());
     }
 
     #[Test]
@@ -44,7 +44,7 @@ final class DialogSerializationTest extends TestCase
         $this->assertSame($dialog->getChatId(), $unserializedDialog->getChatId());
         $this->assertSame($dialog->getUserId(), $unserializedDialog->getUserId());
         $this->assertSame($dialog->ttl(), $unserializedDialog->ttl());
-        $this->assertSame($dialog->isStart(), $unserializedDialog->isStart());
+        $this->assertSame($dialog->isAtStart(), $unserializedDialog->isStart());
     }
 
     #[Test]

--- a/tests/DialogTest.php
+++ b/tests/DialogTest.php
@@ -31,7 +31,7 @@ final class DialogTest extends TestCase
 
         $dialog->start($this->buildUpdateOfRandomType());
 
-        $this->assertTrue($dialog->isEnd());
+        $this->assertTrue($dialog->isComplete());
     }
 
     #[Test]
@@ -49,7 +49,7 @@ final class DialogTest extends TestCase
         $dialog->start($this->buildUpdateOfRandomType());
         $dialog->executeStep($this->buildUpdateOfRandomType());
 
-        $this->assertTrue($dialog->isEnd());
+        $this->assertTrue($dialog->isComplete());
     }
 
     #[Test]
@@ -165,7 +165,7 @@ final class DialogTest extends TestCase
 
             public function step2(): void
             {
-                $this->end();
+                $this->complete();
             }
 
             protected function afterLastStep(Update $update): void

--- a/tests/DialogTest.php
+++ b/tests/DialogTest.php
@@ -47,7 +47,7 @@ final class DialogTest extends TestCase
         };
 
         $dialog->start($this->buildUpdateOfRandomType());
-        $dialog->proceed($this->buildUpdateOfRandomType());
+        $dialog->executeStep($this->buildUpdateOfRandomType());
 
         $this->assertTrue($dialog->isEnd());
     }
@@ -98,8 +98,8 @@ final class DialogTest extends TestCase
             }
         };
 
-        $dialog->proceed($this->buildUpdateOfRandomType());
-        $dialog->proceed($this->buildUpdateOfRandomType());
+        $dialog->executeStep($this->buildUpdateOfRandomType());
+        $dialog->executeStep($this->buildUpdateOfRandomType());
     }
 
     #[Test]
@@ -118,9 +118,9 @@ final class DialogTest extends TestCase
             }
         };
 
-        $dialog->proceed($this->buildUpdateOfRandomType());
-        $dialog->proceed($this->buildUpdateOfRandomType());
-        $dialog->proceed($this->buildUpdateOfRandomType());
+        $dialog->executeStep($this->buildUpdateOfRandomType());
+        $dialog->executeStep($this->buildUpdateOfRandomType());
+        $dialog->executeStep($this->buildUpdateOfRandomType());
 
         $this->assertSame(3, $dialog->count);
     }
@@ -147,11 +147,11 @@ final class DialogTest extends TestCase
             }
         };
 
-        $dialog->proceed($this->buildUpdateOfRandomType());
-        $dialog->proceed($this->buildUpdateOfRandomType());
+        $dialog->executeStep($this->buildUpdateOfRandomType());
+        $dialog->executeStep($this->buildUpdateOfRandomType());
 
         $this->expectException(\LogicException::class);
-        $dialog->proceed($this->buildUpdateOfRandomType());
+        $dialog->executeStep($this->buildUpdateOfRandomType());
     }
 
     #[Test]
@@ -174,9 +174,9 @@ final class DialogTest extends TestCase
             }
         };
 
-        $dialog->proceed($this->buildUpdateOfRandomType());
+        $dialog->executeStep($this->buildUpdateOfRandomType());
 
         $this->expectException(\LogicException::class);
-        $dialog->proceed($this->buildUpdateOfRandomType());
+        $dialog->executeStep($this->buildUpdateOfRandomType());
     }
 }

--- a/tests/ci/console.php
+++ b/tests/ci/console.php
@@ -20,8 +20,8 @@ Artisan::command('telegram:dialog:test {ttl=10}', function (DialogManager $dialo
         /** @var \Telegram\Bot\Objects\Update $update */
         foreach ($updates as $update) {
             // 1. continue active Dialog (if any)
-            if ($dialogs->exists($update)) {
-                $dialogs->proceed($update);
+            if ($dialogs->hasActiveDialog($update)) {
+                $dialogs->processUpdate($update);
                 continue;
             }
 
@@ -32,7 +32,7 @@ Artisan::command('telegram:dialog:test {ttl=10}', function (DialogManager $dialo
             if ($message instanceof \Telegram\Bot\Objects\Message && ($message->text === '/start' || str_contains($message->text, 'hello bot'))) {
                 $dialog = new HelloExampleDialog($chatId);
                 $dialogs->activate($dialog);
-                $dialogs->proceed($update);
+                $dialogs->processUpdate($update);
                 continue;
             }
 


### PR DESCRIPTION
I found some method names confusing (especially 2 `proceed` methods in Dialog and DialogManager), some names were not correct from an English grammar standpoint. In this PR I renamed them, plus added `UPGRADE.md` file.