### PR TITLE
Bugfix in DialogManager, typos in .md, +1 method to Dialogs facade

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ abstract class Dialog
     // State Management
     public function isAtStart(): bool;
     public function isLastStep(): bool;
-    public function isComplete(): bool;
+    public function isCompleted(): bool;
 
     // Lifecycle Hooks
     protected function beforeEveryStep(Update $update, int $stepIndex): void;

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -62,7 +62,7 @@ findDialogKeyForStore()       resolveDialogKey()
 getDialogInstance()           resolveActiveDialog()
 storeDialogState()            persistDialog()
 readDialogState()             retrieveDialog()
-forgetDialogState()           removeDialog()
+forgetDialogState()           forgetDialog()
 ```
 
 Note: These are internal changes and shouldn't affect your application unless you've extended DialogManager.

--- a/src/Laravel/Facades/Dialogs.php
+++ b/src/Laravel/Facades/Dialogs.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static void activate(\KootLabs\TelegramBotDialogs\Dialog $dialog) Activate a given Dialog, so processUpdate() will execute it.
  * @method static void processUpdate(\Telegram\Bot\Objects\Update $update) Pass Update into the active Dialog (if any) to process it.
  * @method static \KootLabs\TelegramBotDialogs\DialogManager setBot(\Telegram\Bot\Api $bot) Change the Bot instance to use for API calls.
+ * @method static void initiateDialog(\KootLabs\TelegramBotDialogs\Dialog $dialog, array $data = []) Initiate a new Dialog from the server side.
  */
 final class Dialogs extends Facade
 {


### PR DESCRIPTION
- DialogManager: fix for multiple switches in processUpdate;
- DialogManager: added missed param in initiateDialog;
- readme.md and upgrade.md - fixed typos;
- added initiateDialog function to Dialogs facade