### PR TITLE
Bugfix in proceedConfiguredStep function in dialog.php: json_encode of reply_markup added

### DIFF
--- a/src/Dialog.php
+++ b/src/Dialog.php
@@ -269,6 +269,12 @@ abstract class Dialog
 
             if (is_array($stepConfig['options'] ?? null)) {
                 $params = [...$params, ...$stepConfig['options']];
+
+                if (is_array($params['reply_markup'] ?? null) && [] != $params['reply_markup']) {
+                    $params['reply_markup'] = json_encode($params['reply_markup']);
+                } else{
+                    unset($params['reply_markup']);
+                }
             }
 
             $this->bot->sendMessage($params);


### PR DESCRIPTION
I think json_encode should be on the side of this package, because the code
<code>
$params['reply_markup'] = (string) $params['reply_markup'];
</code>
in vendor/irazasyed/telegram-bot-sdk/src/Traits/Http.php:137
works well for reply_markup, which is built according to their docs here 
https://telegram-bot-sdk.com/docs/guides/keyboards

Update manually tested for:
<code>
'reply_markup' => [
                    'keyboard' => [
                        ['q', '1'],
                        ['2'],
                    ],
                    'resize_keyboard' => true,
                    'is_persistent' => true,
                ],
</code>
//==============================
<code>
'reply_markup' => [
                    'keyboard' => [
                        [''],
                    ],
                    'resize_keyboard' => true,
                    'is_persistent' => true,
                ],
</code>
//==============================
<code>
'reply_markup' => [
                    'keyboard' => [
                        [],
                    ],
                    'resize_keyboard' => true,
                    'is_persistent' => true,
                ],
</code>
//==============================
<code>
'reply_markup' => [
                    'keyboard' => [],
                    'resize_keyboard' => true,
                    'is_persistent' => true,
                ],
</code>
//==============================
<code>
'reply_markup' => [
                    'resize_keyboard' => true,
                    'is_persistent' => true,
                ],
</code>
//==============================
<code>
'reply_markup' => [],
</code>