### PR TITLE
Reorganize array shape for configured steps

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -30,24 +30,6 @@ The following methods have been renamed to improve clarity and consistency:
 
 Example migration:
 
-```php
-// Before
-if ($dialog->isStart()) {
-    $dialog->proceed();
-    if ($dialog->isEnd()) {
-        $dialog->end();
-    }
-}
-
-// After
-if ($dialog->isAtStart()) {
-    $dialog->performStep();
-    if ($dialog->isCompleted()) {
-        $dialog->complete();
-    }
-}
-```
-
 ### Configuration Changes
 
 If you use configured steps (as an array), the structure has changed:

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -19,6 +19,34 @@ $dialog->ttl()              $dialog->getTtl()
 $dialog->proceed()          $dialog->performStep()  // internal method
 ```
 
+If you use configured steps (as an array), the array shape structure is changed:
+```diff
+[
+    'name' => 'step-name',
+-   'response' => 'Hi!',
++   'sendMessage' => 'Hi!',
+````
+
+if you used "options" key, rename it into "sendMessage" and move "response" into "sendMessage.text":
+```diff
+[
+    'name' => 'step-name',
+-   'response' => 'Hi!',
+-   'options' => ['parse_mode' => 'HTML'],
++   'sendMessage' => ['text' => 'Hi!', 'parse_mode' => 'HTML'],
+```
+
+control flow instructions moved into a "control" subarray, where "end" renamed into "complete"":
+```diff
+[
+    'name' => 'step-name',
+-   'response' => 'Hi!',
+-   'switch' => 'next',
+-   'nextStep' => 'next',
+-   'end' => true,
++   'control' => ['switch' => "next", 'nextStep' => 'next', 'complete' => true],
+```
+
 #### `DialogManager` Class
 
 ```php

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -41,6 +41,7 @@ control flow instructions moved into a "control" subarray, where "end" renamed i
 [
     'name' => 'step-name',
 -   'response' => 'Hi!',
++   'sendMessage' => 'Hi!',
 -   'switch' => 'next',
 -   'nextStep' => 'next',
 -   'end' => true,

--- a/docs/advanced-dialogs.md
+++ b/docs/advanced-dialogs.md
@@ -26,11 +26,8 @@ final class WelcomeDialog extends Dialog
     /**
      * @var list<string|array{
      *   name: string,
-     *   response?: string,
-     *   options?: array<string, mixed>,
-     *   nextStep?: string,
-     *   switch?: string,
-     *   end?: bool
+     *   sendMessage: string|array<string, mixed>,
+     *   control?: array{nextStep?: string, switch?: string, complete?: bool}
      * }>
      */
     protected array $steps = [
@@ -40,15 +37,14 @@ final class WelcomeDialog extends Dialog
         // Configured step with default response
         [
             'name' => 'greeting',
-            'response' => 'Hello! How can I help you today?',
-            'options' => ['parse_mode' => 'HTML'],
+            'sendMessage' => 'Hello! How can I help you today?',
         ],
 
-        // Step with flow control
+        // Step with advanced parameters
         [
             'name' => 'menu',
-            'response' => 'Please choose an option:',
-            'options' => [
+            'sendMessage' => [
+                'text' => 'Please choose an option:', // required key
                 'reply_markup' => [
                     'keyboard' => [
                         ['Help', 'About'],
@@ -64,7 +60,7 @@ final class WelcomeDialog extends Dialog
 
 ### Available Options
 
-The `options` array supports all parameters from the [Telegram sendMessage API](https://core.telegram.org/bots/api#sendmessage), including:
+The `sendMessage` array supports all parameters from the [Telegram sendMessage API](https://core.telegram.org/bots/api#sendmessage), including:
 
 ```php
 [
@@ -83,8 +79,8 @@ Example with formatted text:
 ```php
 [
     'name' => 'formatted_message',
-    'response' => '<b>Bold text</b> and <i>italic text</i>',
-    'options' => [
+    'sendMessage' => [
+        'text' => '<b>Bold text</b> and <i>italic text</i>',
         'parse_mode' => 'HTML',
         'disable_web_page_preview' => true,
     ],
@@ -100,22 +96,22 @@ protected array $steps = [
     // Jump to a specific step after completion
     [
         'name' => 'start',
-        'response' => 'Welcome!',
-        'nextStep' => 'menu',  // Equivalent to $this->nextStep('menu')
+        'sendMessage' => 'Welcome!',
+        'control' => ['nextStep' => 'menu'],  // Equivalent to $this->nextStep('menu')
     ],
 
     // Switch to another step immediately
     [
         'name' => 'help',
-        'response' => 'Showing help...',
-        'switch' => 'help_details',  // Equivalent to $this->switch('help_details')
+        'sendMessage' => 'Showing help...',
+        'control' => ['switch' => 'help_details'],  // Equivalent to $this->switch('help_details')
     ],
 
     // End dialog after a step
     [
         'name' => 'goodbye',
-        'response' => 'Thank you for using our bot!',
-        'end' => true,  // Equivalent to $this->complete()
+        'sendMessage' => 'Thank you for using our bot!',
+        'control' => ['complete' => true],  // Equivalent to $this->complete()
     ],
 ];
 ```

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,23 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="5.26.1@d747f6500b38ac4f7dfc5edbcae6e4b637d7add0">
   <file src="src/Dialog.php">
-    <InvalidOperand>
-      <code><![CDATA[$stepConfig['options']]]></code>
-    </InvalidOperand>
-    <PossiblyUndefinedArrayOffset>
-      <code><![CDATA[$stepConfig['options']]]></code>
-    </PossiblyUndefinedArrayOffset>
+    <ArgumentTypeCoercion>
+      <code><![CDATA[$normalizedStepConfig['control']['nextStep']]]></code>
+      <code><![CDATA[$normalizedStepConfig['control']['switch']]]></code>
+    </ArgumentTypeCoercion>
+    <DocblockTypeContradiction>
+      <code><![CDATA[is_array($stepNameOrConfig)]]></code>
+      <code><![CDATA[is_array($value)]]></code>
+      <code><![CDATA[is_array($value)]]></code>
+    </DocblockTypeContradiction>
+    <InvalidDocblock>
+      <code><![CDATA[abstract class Dialog]]></code>
+    </InvalidDocblock>
+    <MismatchingDocblockParamType>
+      <code><![CDATA[StepConfiguration]]></code>
+      <code><![CDATA[StepConfiguration]]></code>
+    </MismatchingDocblockParamType>
+    <MismatchingDocblockReturnType>
+      <code><![CDATA[NormalizedStepConfiguration]]></code>
+    </MismatchingDocblockReturnType>
+    <NoValue>
+      <code><![CDATA[$stepNameOrConfig]]></code>
+    </NoValue>
     <PropertyNotSetInConstructor>
       <code><![CDATA[$bot]]></code>
     </PropertyNotSetInConstructor>
-    <RedundantConditionGivenDocblockType>
-      <code><![CDATA[is_string($stepNameOrConfig)]]></code>
-      <code><![CDATA[isset($stepConfig['end']) && $stepConfig['end'] === true]]></code>
-    </RedundantConditionGivenDocblockType>
-    <RiskyTruthyFalsyComparison>
-      <code><![CDATA[empty($stepConfig['nextStep'])]]></code>
-      <code><![CDATA[empty($stepConfig['switch'])]]></code>
-    </RiskyTruthyFalsyComparison>
   </file>
   <file src="src/DialogManager.php">
     <LessSpecificReturnStatement>
@@ -71,7 +79,8 @@
             protected array $steps = [
                 [
                     'name' => 'first',
-                    'end' => true,
+                    'sendMessage' => 'Hi!',
+                    'control' => ['complete' => true],
                 ],
                 [
                     'name' => 'second',
@@ -85,13 +94,16 @@
             protected array $steps = [
                 [
                     'name' => 'first',
-                    'switch' => 'third',
+                    'sendMessage' => 'Hi!',
+                    'control' => ['switch' => 'third'],
                 ],
                 [
                     'name' => 'second',
+                    'sendMessage' => 'Hi again (2)',
                 ],
                 [
                     'name' => 'third',
+                    'sendMessage' => 'Hi again (3)',
                 ],
             ];
 
@@ -106,14 +118,11 @@
             protected array $steps = [
                 [
                     'name' => 'first',
-                    'nextStep' => 'third',
+                    'sendMessage' => 'Hi!',
+                    'control' => ['nextStep' => 'third'],
                 ],
-                [
-                    'name' => 'second',
-                ],
-                [
-                    'name' => 'third',
-                ],
+                ['name' => 'second', 'sendMessage' => 'this is second'],
+                ['name' => 'third', 'sendMessage' => 'this is third'],
             ];
 
             protected function afterEveryStep(Update $update, int $stepIndex): void
@@ -129,6 +138,7 @@
             protected array $steps = [
                 [
                     'name' => 'first',
+                    'sendMessage' => 'Hi!',
                 ],
             ];
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -63,8 +63,33 @@
       <code><![CDATA[$steps]]></code>
       <code><![CDATA[$steps]]></code>
       <code><![CDATA[$steps]]></code>
+      <code><![CDATA[$steps]]></code>
+      <code><![CDATA[$steps]]></code>
+      <code><![CDATA[$steps]]></code>
+      <code><![CDATA[$steps]]></code>
     </NonInvariantDocblockPropertyType>
     <PropertyNotSetInConstructor>
+      <code><![CDATA[class (self::RANDOM_CHAT_ID) extends Dialog {
+            /** @inheritDoc */
+            protected array $steps = [
+                [
+                    'name' => 'first',
+                    'sendMessage' => [
+                        'parse_mode' => 'HTML',
+                        // 'text' key is missing
+                    ],
+                ],
+            ];
+        }]]></code>
+      <code><![CDATA[class (self::RANDOM_CHAT_ID) extends Dialog {
+            /** @inheritDoc */
+            protected array $steps = [
+                [
+                    'name' => 'first',
+                    // 'sendMessage' key is missing
+                ],
+            ];
+        }]]></code>
       <code><![CDATA[class (self::RANDOM_CHAT_ID) extends Dialog {
             /** @inheritDoc */
             protected array $steps = [
@@ -84,6 +109,34 @@
                 ],
                 [
                     'name' => 'second',
+                ],
+            ];
+        }]]></code>
+      <code><![CDATA[class (self::RANDOM_CHAT_ID, $bot) extends Dialog {
+            /** @inheritDoc */
+            protected array $steps = [
+                [
+                    'name' => 'first',
+                    'sendMessage' => [
+                        'text' => 'Hi!',
+                        'reply_markup' => '{"inline_keyboard":[[{"text":"Button 1","callback_data":"btn1"}]]}',
+                    ],
+                ],
+            ];
+        }]]></code>
+      <code><![CDATA[class (self::RANDOM_CHAT_ID, $bot) extends Dialog {
+            /** @inheritDoc */
+            protected array $steps = [
+                [
+                    'name' => 'first',
+                    'sendMessage' => [
+                        'text' => 'Hi!',
+                        'reply_markup' => [
+                            'inline_keyboard' => [
+                                [['text' => 'Button 1', 'callback_data' => 'btn1']],
+                            ],
+                        ],
+                    ],
                 ],
             ];
         }]]></code>
@@ -252,6 +305,28 @@
             {
                 ++$this->count;
                 $this->nextStep('step1');
+            }
+        }]]></code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/Fakes/FakeBot.php">
+    <PropertyNotSetInConstructor>
+      <code><![CDATA[class('fake', false, $this->getGuzzleHttpClient([
+            $this->makeFakeServerResponse($resultData, $statusCode, $headers),
+            $this->makeFakeServerResponse($resultData, $statusCode, $headers),
+            $this->makeFakeServerResponse($resultData, $statusCode, $headers),
+        ])) extends Api {
+            private array $lastSentMessage = [];
+
+            public function sendMessage(array $params): \Telegram\Bot\Objects\Message
+            {
+                $this->lastSentMessage = $params;
+                return parent::sendMessage($params);
+            }
+
+            public function getLastSentMessage(): array
+            {
+                return $this->lastSentMessage;
             }
         }]]></code>
     </PropertyNotSetInConstructor>

--- a/src/Dialog.php
+++ b/src/Dialog.php
@@ -347,7 +347,7 @@ abstract class Dialog
         ];
 
         if (is_array($normalized['sendMessage']['reply_markup'] ?? null)) {
-            $normalized['reply_markup'] = json_encode($normalized['sendMessage']['reply_markup'], \JSON_THROW_ON_ERROR);
+            $normalized['sendMessage']['reply_markup'] = json_encode($normalized['sendMessage']['reply_markup'], \JSON_THROW_ON_ERROR);
         }
 
         return $normalized;

--- a/src/Dialog.php
+++ b/src/Dialog.php
@@ -327,7 +327,7 @@ abstract class Dialog
             throw new InvalidDialogStep('Configurable Dialog step does not contain required “name” key.');
         }
 
-        if (!is_string($rawStepConfig['sendMessage']) && ! is_string($rawStepConfig['sendMessage']['text'])) {
+        if (! is_string($rawStepConfig['sendMessage'] ?? null) && ! is_string($rawStepConfig['sendMessage']['text']  ?? null)) {
             throw new InvalidDialogStep('Configurable Dialog step does not contain required “sendMessage.text” key.');
         }
 

--- a/tests/DialogConfigurableStepsTest.php
+++ b/tests/DialogConfigurableStepsTest.php
@@ -78,6 +78,67 @@ final class DialogConfigurableStepsTest extends TestCase
     }
 
     #[Test]
+    public function it_json_encodes_reply_markup_when_array(): void
+    {
+        $bot = $this->createBotWithQueuedResponse();
+        $replyMarkup = [
+            'inline_keyboard' => [
+                [['text' => 'Button 1', 'callback_data' => 'btn1']],
+            ],
+        ];
+
+        $dialog = new class (self::RANDOM_CHAT_ID, $bot) extends Dialog {
+            /** @inheritDoc */
+            protected array $steps = [
+                [
+                    'name' => 'first',
+                    'sendMessage' => [
+                        'text' => 'Hi!',
+                        'reply_markup' => [
+                            'inline_keyboard' => [
+                                [['text' => 'Button 1', 'callback_data' => 'btn1']],
+                            ],
+                        ],
+                    ],
+                ],
+            ];
+        };
+
+        $dialog->performStep($this->buildUpdateOfRandomType());
+
+        $expectedJson = json_encode($replyMarkup, \JSON_THROW_ON_ERROR);
+        $this->assertSame($expectedJson, $bot->getLastSentMessage()['reply_markup']);
+    }
+
+    #[Test]
+    public function it_preserves_reply_markup_when_already_json_string(): void
+    {
+        $bot = $this->createBotWithQueuedResponse();
+        $replyMarkup = json_encode([
+            'inline_keyboard' => [
+                [['text' => 'Button 1', 'callback_data' => 'btn1']],
+            ],
+        ], JSON_THROW_ON_ERROR);
+
+        $dialog = new class (self::RANDOM_CHAT_ID, $bot) extends Dialog {
+            /** @inheritDoc */
+            protected array $steps = [
+                [
+                    'name' => 'first',
+                    'sendMessage' => [
+                        'text' => 'Hi!',
+                        'reply_markup' => '{"inline_keyboard":[[{"text":"Button 1","callback_data":"btn1"}]]}',
+                    ],
+                ],
+            ];
+        };
+
+        $dialog->performStep($this->buildUpdateOfRandomType());
+
+        $this->assertSame($replyMarkup, $bot->getLastSentMessage()['reply_markup']);
+    }
+
+    #[Test]
     public function it_switches_to_another_step(): void
     {
         $bot = $this->createBotWithQueuedResponse();

--- a/tests/DialogConfigurableStepsTest.php
+++ b/tests/DialogConfigurableStepsTest.php
@@ -39,6 +39,45 @@ final class DialogConfigurableStepsTest extends TestCase
     }
 
     #[Test]
+    public function it_throws_an_exception_when_step_does_not_have_sendMessage(): void
+    {
+        $dialog = new class (self::RANDOM_CHAT_ID) extends Dialog {
+            /** @inheritDoc */
+            protected array $steps = [
+                [
+                    'name' => 'first',
+                    // 'sendMessage' key is missing
+                ],
+            ];
+        };
+
+        $this->expectException(InvalidDialogStep::class);
+
+        $dialog->performStep($this->buildUpdateOfRandomType());
+    }
+
+    #[Test]
+    public function it_throws_an_exception_when_step_does_not_have_sendMessage_text(): void
+    {
+        $dialog = new class (self::RANDOM_CHAT_ID) extends Dialog {
+            /** @inheritDoc */
+            protected array $steps = [
+                [
+                    'name' => 'first',
+                    'sendMessage' => [
+                        'parse_mode' => 'HTML',
+                        // 'text' key is missing
+                    ],
+                ],
+            ];
+        };
+
+        $this->expectException(InvalidDialogStep::class);
+
+        $dialog->performStep($this->buildUpdateOfRandomType());
+    }
+
+    #[Test]
     public function it_switches_to_another_step(): void
     {
         $bot = $this->createBotWithQueuedResponse();

--- a/tests/DialogConfigurableStepsTest.php
+++ b/tests/DialogConfigurableStepsTest.php
@@ -50,13 +50,16 @@ final class DialogConfigurableStepsTest extends TestCase
             protected array $steps = [
                 [
                     'name' => 'first',
-                    'switch' => 'third',
+                    'sendMessage' => 'Hi!',
+                    'control' => ['switch' => 'third'],
                 ],
                 [
                     'name' => 'second',
+                    'sendMessage' => 'Hi again (2)',
                 ],
                 [
                     'name' => 'third',
+                    'sendMessage' => 'Hi again (3)',
                 ],
             ];
 
@@ -90,14 +93,11 @@ final class DialogConfigurableStepsTest extends TestCase
             protected array $steps = [
                 [
                     'name' => 'first',
-                    'nextStep' => 'third',
+                    'sendMessage' => 'Hi!',
+                    'control' => ['nextStep' => 'third'],
                 ],
-                [
-                    'name' => 'second',
-                ],
-                [
-                    'name' => 'third',
-                ],
+                ['name' => 'second', 'sendMessage' => 'this is second'],
+                ['name' => 'third', 'sendMessage' => 'this is third'],
             ];
 
             protected function afterEveryStep(Update $update, int $stepIndex): void
@@ -122,7 +122,8 @@ final class DialogConfigurableStepsTest extends TestCase
             protected array $steps = [
                 [
                     'name' => 'first',
-                    'end' => true,
+                    'sendMessage' => 'Hi!',
+                    'control' => ['complete' => true],
                 ],
                 [
                     'name' => 'second',
@@ -148,6 +149,7 @@ final class DialogConfigurableStepsTest extends TestCase
             protected array $steps = [
                 [
                     'name' => 'first',
+                    'sendMessage' => 'Hi!',
                 ],
             ];
 

--- a/tests/DialogManagerTest.php
+++ b/tests/DialogManagerTest.php
@@ -7,6 +7,7 @@ namespace KootLabs\TelegramBotDialogs\Tests;
 use KootLabs\TelegramBotDialogs\DialogManager;
 use KootLabs\TelegramBotDialogs\DialogRepository;
 use KootLabs\TelegramBotDialogs\Dialogs\HelloExampleDialog;
+use KootLabs\TelegramBotDialogs\Tests\Fakes\FakeBot;
 use KootLabs\TelegramBotDialogs\Tests\TestDialogs\PassiveTestDialog;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -22,6 +23,8 @@ use Telegram\Bot\Objects\Update;
 #[UsesClass(\KootLabs\TelegramBotDialogs\DialogRepository::class)]
 final class DialogManagerTest extends TestCase
 {
+    use FakeBot;
+
     private const RANDOM_CHAT_ID = 42;
     private const RANDOM_USER_ID = 110;
 
@@ -92,10 +95,11 @@ final class DialogManagerTest extends TestCase
     public function it_throws_custom_exception_when_switch_to_another_step(): void
     {
         $dialogManager = $this->instantiateDialogManager();
-        $dialog = new PassiveTestDialog(self::RANDOM_CHAT_ID);
-
+        $dialog = new PassiveTestDialog(self::RANDOM_CHAT_ID, $this->createBotWithQueuedResponse());
         $dialogManager->activate($dialog);
+
         $this->expectException(\LogicException::class);
+
         $dialog->performStep(new Update(['message' => ['chat' => ['id' => self::RANDOM_CHAT_ID]]]));
     }
 

--- a/tests/Fakes/FakeBot.php
+++ b/tests/Fakes/FakeBot.php
@@ -10,12 +10,16 @@ trait FakeBot
 {
     use FakeHttp;
 
-    public function createBotWithQueuedResponse(array $data = [], int $statusCode = 200, array $headers = []): Api
+    protected function createBotWithQueuedResponse(array $resultData = [], int $statusCode = 200, array $headers = []): Api
     {
         return new Api(
             'fake',
             false,
-            $this->getGuzzleHttpClient([$this->makeFakeServerResponse($data, $statusCode, $headers)])
+            $this->getGuzzleHttpClient([
+                $this->makeFakeServerResponse($resultData, $statusCode, $headers),
+                $this->makeFakeServerResponse($resultData, $statusCode, $headers),
+                $this->makeFakeServerResponse($resultData, $statusCode, $headers),
+            ])
         );
     }
 }

--- a/tests/Fakes/FakeBot.php
+++ b/tests/Fakes/FakeBot.php
@@ -10,16 +10,29 @@ trait FakeBot
 {
     use FakeHttp;
 
+    private array $lastSentMessage = [];
+
     protected function createBotWithQueuedResponse(array $resultData = [], int $statusCode = 200, array $headers = []): Api
     {
-        return new Api(
-            'fake',
-            false,
-            $this->getGuzzleHttpClient([
-                $this->makeFakeServerResponse($resultData, $statusCode, $headers),
-                $this->makeFakeServerResponse($resultData, $statusCode, $headers),
-                $this->makeFakeServerResponse($resultData, $statusCode, $headers),
-            ])
-        );
+        $bot = new class('fake', false, $this->getGuzzleHttpClient([
+            $this->makeFakeServerResponse($resultData, $statusCode, $headers),
+            $this->makeFakeServerResponse($resultData, $statusCode, $headers),
+            $this->makeFakeServerResponse($resultData, $statusCode, $headers),
+        ])) extends Api {
+            private array $lastSentMessage = [];
+
+            public function sendMessage(array $params): \Telegram\Bot\Objects\Message
+            {
+                $this->lastSentMessage = $params;
+                return parent::sendMessage($params);
+            }
+
+            public function getLastSentMessage(): array
+            {
+                return $this->lastSentMessage;
+            }
+        };
+
+        return $bot;
     }
 }

--- a/tests/TestDialogs/PassiveTestDialog.php
+++ b/tests/TestDialogs/PassiveTestDialog.php
@@ -8,17 +8,18 @@ use KootLabs\TelegramBotDialogs\Dialog;
 use Telegram\Bot\Objects\Update;
 
 /**
- * An example of Dialog class, which only listens and doesn't send anything, for test purposes.
+ * An example of Dialog class, which only listens to and doesn't send anything, for test purposes.
  * @internal
  * @api
  */
 final class PassiveTestDialog extends Dialog
 {
-    /** @var list<non-empty-string|array{name: string, switch: non-empty-string}> List of method to execute. The order defines the sequence */
+    /** @var list<non-empty-string|array{name: string, sendMessage: string|array, control?: array}> List of method to execute. The order defines the sequence */
     protected array $steps = [
         [
             'name' => 'step1',
-            'switch' => 'step2',
+            'sendMessage' => 'Hi!',
+            'control' => ['switch' => 'step2'],
         ],
         'step2',
         'step3',
@@ -27,7 +28,7 @@ final class PassiveTestDialog extends Dialog
 
     public function step2(Update $update): void
     {
-        $this->switch("step4");
+        $this->switch('step4');
     }
 
     public function step3(Update $update): void {}


### PR DESCRIPTION
Goal is to make it more developer-friendly:
 - use consistent naming (end vs complete)
 - separate telegram parameters from internal control flow parameters
 - add more step configuration validation

An updated https://github.com/koot-labs/telegram-bot-dialogs/blob/reorganize-configured-steps/UPGRADE.md convers all the cases.

PS: it's probably the latest BC before the 1.0 release