### PR TITLE
Bugfix in initiateDialog of DialogManager for empty updateData param

### DIFF
--- a/src/DialogManager.php
+++ b/src/DialogManager.php
@@ -61,11 +61,23 @@ final class DialogManager
     {
         $this->activate($dialog);
 
-        $this->processUpdate(new BotInitiatedUpdate($updateData));
+        // To get instance of initiated Dialog from a Storage in processUpdate
+        if (empty($updateData)) {
+            $updateData = [
+                'message' => [
+                    'chat' => [
+                        'id' => $dialog->getChatId(),
+                    ],
+                ],
+            ];
 
-        $dialog->isCompleted()
-            ? $this->forgetDialog($dialog)
-            : $this->persistDialog($dialog);
+            $userId = $dialog->getUserId();
+            if ($userId !== null){
+                $updateData['message']['from'] = ['id' => $userId];
+            }
+        }
+
+        $this->processUpdate(new BotInitiatedUpdate($updateData));
     }
 
     /**


### PR DESCRIPTION
initiateDialog in DialogManager calls processUpdate, which then calls resolveActiveDialog and then resolveDialogKey. all 3 methods use Update object as parameter to get chat id and user id (if exists) from it to generate dialog key and get active dialog instance from storage. Update object is constructed from $updateData (as initiateDialog param) here. so if updateData is empty array or filled wrong, resolveDialogKey will fail to generage dialog key and get active dialog from storage. to fill updateData correctly is the task of package user (we may not handle all cases). but as we propose empty  updateData by default we should handle this case. so i added minimal valid updateData content to make chat id and user id (if exists) available from constructed Update object.

also removed from the end of initiateDialog this code:
```php
if ($dialog->isCompleted()) {
    $this->forgetDialog($dialog);
} else {
    $this->persistDialog($dialog);
}
```

as duplicate. It is used in processUpdate, called from initiateDialog. so no need to use it again in the end of initiateDialog.
        
        