### PR TITLE
initiateDialog flow updated in DialogManager

### DIFF
--- a/src/DialogManager.php
+++ b/src/DialogManager.php
@@ -61,11 +61,23 @@ final class DialogManager
     {
         $this->activate($dialog);
 
-        $this->processUpdate(new BotInitiatedUpdate($updateData));
+        // To get instance of initiated Dialog from a Storage in processUpdate
+        if (empty($updateData)) {
+            $updateData = [
+                'message' => [
+                    'chat' => [
+                        'id' => $dialog->getChatId(),
+                    ],
+                ],
+            ];
 
-        $dialog->isCompleted()
-            ? $this->forgetDialog($dialog)
-            : $this->persistDialog($dialog);
+            $userId = $dialog->getUserId();
+            if ($userId !== null){
+                $updateData['message']['from'] = ['id' => $userId];
+            }
+        }
+
+        $this->processUpdate(new BotInitiatedUpdate($updateData));
     }
 
     /**


### PR DESCRIPTION
I implemented full flow for initiating a dialog from server side. Thus initiateDialog is updated to work properly:

1) $updateData param should be populated with chatId (and userId) if empty to make processUpdate possible
2) forgetActiveDialog added before activate of initiated one, because there is only 1 dialog may be active
3) This part of code
`
if ($dialog->isCompleted()) {
    $this->forgetDialog($dialog);
} else {
    $this->persistDialog($dialog);
}
`
removed as duplicate, because it is present in processUpdate already